### PR TITLE
fix: update TTS test for _safe_play wrapper

### DIFF
--- a/tests/unit/test_tts_manager.py
+++ b/tests/unit/test_tts_manager.py
@@ -509,10 +509,10 @@ class TestPlayAudioAsync:
 
             self.manager._play_audio_async(mock_audio, "Speaker")
 
-            mock_thread_class.assert_called_once_with(
-                target=self.manager._play_audio_blocking,
-                args=(mock_audio, "Speaker")
-            )
+            mock_thread_class.assert_called_once()
+            # Target is now a _safe_play wrapper closure, not _play_audio_blocking directly
+            target = mock_thread_class.call_args[1].get('target', mock_thread_class.call_args[0][0] if mock_thread_class.call_args[0] else None)
+            assert callable(target)
             assert mock_thread.daemon is True
             mock_thread.start.assert_called_once()
 


### PR DESCRIPTION
## Summary
- Updates `test_play_audio_async_creates_daemon_thread` to match the `_safe_play` closure pattern from Bug 4.2 fix
- Test now verifies thread creation and daemon flag without asserting exact closure target/args

## Test plan
- [x] Test passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)